### PR TITLE
Broken commit: Need to figure out how to pass nixpkgs-unstable

### DIFF
--- a/base/common/nix-store.nix
+++ b/base/common/nix-store.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, ... }:
+{
+  nix = {
+    gc.automatic = true;
+    autoOptimiseStore = true;
+
+    # Make use of latest `nix` to allow usage of `nix flake`s.
+    package = pkgs.nix_2_5;
+    extraOptions = ''
+      experimental-features = nix-command flakes
+    '';
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,6 @@
 {
   "nodes": {
-    "nixos": {
+    "nixpkgs": {
       "locked": {
         "lastModified": 1642961095,
         "narHash": "sha256-RLatktZmvwFBOyqdoIk4qdS4OGKB7aKIvvs4ZP2L8D8=",
@@ -16,9 +16,26 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1643119265,
+        "narHash": "sha256-mmDEctIkHSWcC/HRpeaw6QOe+DbNOSzc0wsXAHOZWwo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b05d2077ebe219f6a47825767f8bab5c6211d200",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixos": "nixos"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,13 +3,20 @@
   description = "x10an4's NixOS Live ISO image";
   inputs.nixos.url = "github:nixos/nixpkgs/nixos-21.11";
 
-  outputs = { self, nixos }: {
+  outputs = {
+    self
+    , nixos
+    , ...
+  }: let
+    systemArch = "x86_64-linux";
+  in {
     nixosConfigurations = let
       # Shared base configuration.
       baseConfig = {
-        system = "x86_64-linux";
+        system = systemArch;
         modules = [
           # Common system modules...
+          ./base/common/nix-store.nix
         ];
       };
     in {

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,14 @@
 {
   # Inspired/stolen from: https://hoverbear.org/blog/nix-flake-live-media/
   description = "x10an4's NixOS Live ISO image";
-  inputs.nixos.url = "github:nixos/nixpkgs/nixos-21.11";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
 
   outputs = {
     self
-    , nixos
+    , nixpkgs
     , ...
   }: let
     systemArch = "x86_64-linux";
@@ -20,13 +23,13 @@
         ];
       };
     in {
-      installIso = nixos.lib.nixosSystem {
+      installIso = nixpkgs.lib.nixosSystem {
         inherit (baseConfig) system;
         modules = baseConfig.modules ++ [
-          "${nixos}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
+          "${nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
         ];
       };
-      initialSystem = nixos.lib.nixosSystem {
+      initialSystem = nixpkgs.lib.nixosSystem {
         inherit (baseConfig) system;
         modules = baseConfig.modules ++ [
           # Modules for installed systems only.


### PR DESCRIPTION
From flake.nix down to base/common/nix-store.nix...

I get this error:
```
[2022-01-26 15:39:41] 0 x10an14@x10-desktop:
-> $ nix build .#nixosConfigurations.installIso.config.system.build.isoImage
error: attribute 'nix_2_5' missing

       at /nix/store/cdf5p0vx8r6xz1abkj8zcjkdhbmnd9n6-source/base/common/nix-store.nix:8:15:

            7|     # Make use of latest `nix` to allow usage of `nix flake`s.
            8|     package = pkgs.nix_2_5;
             |               ^
            9|     extraOptions = ''
(use '--show-trace' to show detailed location information)
[2022-01-26 15:39:43] 1 x10an14@x10-desktop:
-> $
```