### PR TITLE
Btrfs encrypted boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This repo is my NixOS flake'd config, initiated/inspired by: https://hoverbear.o
 ```
 sudo nixos-rebuild switch --flake ".#$(hostname)"
 ```
+### How to test build of system
+```
+nix build .#nixosConfigurations.initialSystem.config.system.build.toplevel
+```
 
 ## How to make ISO and install on new machine
 ```

--- a/config/encrypted-boot.nix
+++ b/config/encrypted-boot.nix
@@ -1,0 +1,55 @@
+{ config, ... }:
+
+let
+  btrfsMountOptions = [
+    "noatime"
+    "compress=zstd"
+  ];
+
+  # TODO: receive the two below variables as input from another file, make this a module
+  # AKA don't hard-code...
+  fsDevices = {
+    efiPartitionUuid = "/dev/disk/by-partuuid/XXX";
+    swap.unlockedUuid = "/dev/disk/by-partuuid/XXX";
+    root.unlockedUuid = "/dev/disk/by-partuuid/XXX";
+  };
+  btrfsDevices = {
+    "/" = { subvol = "@"; neededForBoot = true; };
+    "/containercow" = { subvol = "@containercow"; };
+    "/home" = { subvol = "@home"; };
+    "/nix" = { subvol = "@nix"; };
+    "/persist" = { subvol = "@persist"; neededForBoot = true; };
+    "/var/log" = { subvol = "@log"; neededForBoot = true; };
+  };
+in {
+  # TODO: Decide if this block should live here or get moved somewhere else
+  # it is necessary for this to compile at time of this commit.
+  boot.loader = {
+    efi = {
+      canTouchEfiVariables = true;
+      efiSysMountPoint = "/efi";
+    };
+    grub = {
+      enable = true;
+      device = "nodev";
+      version = 2;
+      efiSupport = true;
+      enableCryptodisk = true;
+    };
+  };
+
+  fileSystems = builtins.mapAttrs (
+    mountPoint: btrfsDevice: {
+      device = fsDevices.root.unlockedUuid;
+      fsType = "btrfs";
+      options = [ "subvol=${btrfsDevice.subvol}" ] ++ btrfsMountOptions;
+    } // removeAttrs btrfsDevice [ "subvol" ]
+  ) btrfsDevices // {
+    "/efi" = {
+      device = fsDevices.efiPartitionUuid;
+      fsType = "vfat";
+    };
+  };
+
+  swapDevices = [ { device = fsDevices.swap.unlockedUuid; } ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,10 @@
       initialSystem = nixpkgs.lib.nixosSystem {
         inherit (baseConfig) system;
         modules = baseConfig.modules ++ [
+          {nixpkgs.pkgs = pkgs;}
+
           # Modules for installed systems only.
+          ./config/encrypted-boot.nix
         ];
       };
     };


### PR DESCRIPTION
Unable to compile =/

```
[2022-01-26 22:00:43] 0 x10an14@x10-desktop:~/sr.ht/nixos-config
-> $ nix build .#initialSystem
warning: Git tree '/home/x10an14/Documents/sourcehut/nixos-config' is dirty
error: flake 'git+file:///home/x10an14/Documents/sourcehut/nixos-config' does not provide attribute 'packages.x86_64-linux.initialSystem', 'legacyPackages.x86_64-linux.initialSystem' or 'initialSystem'
[2022-01-26 22:00:48] 1 x10an14@x10-desktop:~/sr.ht/nixos-config
-> $
```